### PR TITLE
patient에 피검사 데이터 출력

### DIFF
--- a/front/src/Components/Patient.css
+++ b/front/src/Components/Patient.css
@@ -9,8 +9,9 @@
 }
 
 .patient-details h3 {
-  margin-bottom: 20px;
+  margin-bottom: 17px;
 }
+
 
 .back-button {
   padding: 6px 12px;
@@ -96,7 +97,21 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 17px;
+}
+
+.blood-test-title {
+  width: 300px;  /* 고정된 너비 설정 */
+  display: flex;
+  justify-content: space-between;  /* 양끝 정렬 */
+  align-items: center;
+}
+
+.blood-test-title h2 {
+  margin: 0;
+  flex: 1;  /* 남은 공간 차지 */
+  text-align: center;  /* 가운데 정렬 */
+  padding-right: 80px;  /* 버튼 영역만큼 오른쪽 패딩 */
 }
 
 .blood-test-button {
@@ -107,6 +122,8 @@
   border-radius: 4px;
   cursor: pointer;
   font-size: 14px;
+  margin-right: 14px;
+
 }
 
 .data-container {
@@ -287,4 +304,137 @@
 
 .loading-message {
   background-color: #f3f4f6;
+}
+
+.abnormal-count {
+  color: #000000;
+}
+
+.abnormal-count .count {
+  color: #d32f2f;
+  font-size: 1.45em;
+  font-weight: bold;
+}
+
+.blood-test-results {
+  padding: 20px;
+}
+
+.blood-test-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;  /* 30px에서 축소 */
+  padding-bottom: 15px;  /* 20px에서 축소 */
+  border-bottom: 1px solid #eee;
+}
+ 
+ .blood-test-header h2 {
+  margin: 0;
+  text-align: center; 
+  font-size: 25px;
+ }
+ 
+ .raw-data-button {
+  color: #888;
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.85em;
+  white-space: nowrap;
+  min-width: 80px;  /* 최소 너비 설정 */
+  padding-left: 10px;
+
+}
+
+.raw-data-button:hover {
+  color: #333;
+}
+
+.raw-data {
+  text-align: left;
+  padding: 20px;
+  background-color: #f8f9fa;
+}
+
+.abnormal-circles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.circle-item {
+  text-align: center;
+}
+
+.circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 4px solid #ff4444;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle .value {
+  font-size: 20px;
+  color: #ff4444;
+}
+
+.circle .range {
+  font-size: 12px;
+  color: #666;
+}
+
+.item-name {
+  margin-top: 10px;
+  font-size: 14px;
+}
+
+.result-text {
+  text-align: center;
+  margin-top: 44px;
+  font-size: 25px;
+}
+
+.abnormal-count {
+  color: #000000;
+}
+
+.abnormal-count .count {
+  color: #d32f2f;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+/* 테이블 스타일 추가 */
+.raw-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+.raw-data-table th,
+.raw-data-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+.raw-data-table th {
+  background-color: #f5f5f5;
+  text-align: center;
+}
+.raw-data-table td {
+  text-align: center;
+}
+
+.raw-data-table tr:nth-child(even) {
+  background-color: #f9f9f9;
 }

--- a/front/src/Components/list.css
+++ b/front/src/Components/list.css
@@ -252,27 +252,48 @@ th {
 }
 
 /* 컬럼 너비 설정 */
-table th:nth-child(1), table td:nth-child(1) { width: 8%; }  /* 환자번호 */
-table th:nth-child(2), table td:nth-child(2) { width: 10%; } /* 이름 */
-table th:nth-child(3), table td:nth-child(3) { width: 6%; }  /* 성별 */
-table th:nth-child(4), table td:nth-child(4) { width: 10%; } /* 생년월일 */
-table th:nth-child(5), table td:nth-child(5) { width: 6%; }  /* 나이 */
-table th:nth-child(6), table td:nth-child(6) { width: 15%; } /* 주소 */
-table th:nth-child(7), table td:nth-child(7) { width: 8%; }  /* 임신여부 */
-table th:nth-child(8), table td:nth-child(8) { width: 8%; }  /* 통증점수 */
-table th:nth-child(9), table td:nth-child(9) { width: 8%; }  /* 체류시간 */
-table th:nth-child(10), table td:nth-child(10) { width: 6%; } /* TAS */
-table th:nth-child(11), table td:nth-child(11) { width: 15%; } /* 상세정보 */
+table th:nth-child(1), table td:nth-child(1) { width: 8%; }   /* 환자번호 */
+table th:nth-child(2), table td:nth-child(2) { width: 6%; }   /* 이름 */
+table th:nth-child(3), table td:nth-child(3) { width: 5%; }   /* 성별 */
+table th:nth-child(4), table td:nth-child(4) { width: 8%; }   /* 생년월일 */
+table th:nth-child(5), table td:nth-child(5) { width: 5%; }   /* 나이 */
+table th:nth-child(6), table td:nth-child(6) { width: 12%; }  /* 주소 */
+table th:nth-child(7), table td:nth-child(7) { width: 7%; }   /* 임신여부 */
+table th:nth-child(8), table td:nth-child(8) { width: 7%; }   /* 통증점수 */
+table th:nth-child(9), table td:nth-child(9) { width: 12%; }  /* 방문시간 */
+table th:nth-child(10), table td:nth-child(10) { width: 9%; } /* 체류시간 */
+table th:nth-child(11), table td:nth-child(11) { width: 5%; } /* TAS */
+table th:nth-child(12), table td:nth-child(12) { width: 15%; } /* 상세정보 */
+
+table th:nth-child(9), table td:nth-child(9) {
+  height: 69.1px;          /* 셀 높이 고정 */
+  line-height: 1.3;      /* 줄간격 조절 */
+  padding: 8px 12px;     /* 패딩 조절 */
+}
+
+/* 방문시간 크기 크우려고 위아래 분리 */
+table td:nth-child(9) br {
+  margin-bottom: 4px;
+  display: block;
+}
+
+/* 시간부분 글자 키우기 */
+table td:nth-child(9) > :last-child {
+  font-size: 1.02em;
+}
 
 /* 중앙 정렬이 필요한 컬럼들 */
 table th:nth-child(1), table td:nth-child(1),
 table th:nth-child(3), table td:nth-child(3),
+table th:nth-child(4), table td:nth-child(4),
 table th:nth-child(5), table td:nth-child(5),
+table th:nth-child(6), table td:nth-child(6),
 table th:nth-child(7), table td:nth-child(7),
 table th:nth-child(8), table td:nth-child(8),
 table th:nth-child(9), table td:nth-child(9),
 table th:nth-child(10), table td:nth-child(10),
-table th:nth-child(11), table td:nth-child(11) {
+table th:nth-child(11), table td:nth-child(11),
+table th:nth-child(12), table td:nth-child(12) {
   text-align: center;
 }
 

--- a/front/src/Components/list.js
+++ b/front/src/Components/list.js
@@ -9,7 +9,7 @@ const filterLabels = {
   },
   pregnancystatus: {
     name: '임신 여부',
-    values: { '0': 'No', '1': 'Yes' }
+    values: { '0': 'No', '1': 'Yes', '-': 'No' }
   },
   tas: {
     name: 'KTAS',
@@ -74,7 +74,7 @@ function List({
     }
   }, [ktasFilter]);
 
-  const patientsPerPage = 5;
+  const patientsPerPage = 10;
   const indexOfLastPatient = currentPage * patientsPerPage;
   const indexOfFirstPatient = indexOfLastPatient - patientsPerPage;
   const currentPatients = patientList.slice(indexOfFirstPatient, indexOfLastPatient);
@@ -250,7 +250,7 @@ function List({
                     <label>
                       <input
                         type="checkbox"
-                        checked={selectedFilters.pregnancystatus.includes('0')}
+                        checked={selectedFilters.pregnancystatus.includes('0') || selectedFilters.pregnancystatus.includes('-')}
                         onChange={() => handleFilterChange('pregnancystatus', '0')}
                       />
                       No
@@ -332,6 +332,7 @@ function List({
                 <th>주소</th>
                 <th>임신 여부</th>
                 <th>통증 점수</th>
+                <th>방문 시간</th>
                 <th>체류 시간</th>
                 <th>KTAS</th>
                 <th>상세 정보</th>
@@ -347,9 +348,28 @@ function List({
                     <td>{patient.birthdate}</td>
                     <td>{patient.age}</td>
                     <td>{patient.address}</td>
-                    <td>{patient.pregnancystatus === "0" ? "N" : "Y"}</td>
+                    <td>{patient.pregnancystatus === "0" ? "N" : patient.pregnancystatus === "1" ? "Y" : "-"}</td>
                     <td>{patient.visits?.[0]?.pain || '-'}</td>
-                    <td>{patient.visits?.[0]?.los_hours || '-'}시간</td>
+                    <td>
+                      {patient.visits?.length > 0 ? (
+                        <>
+                          {new Date(patient.visits[patient.visits.length - 1].visit_date).toLocaleDateString('ko-KR', {
+                            year: 'numeric',
+                            month: '2-digit',
+                            day: '2-digit'
+                          }).replace(/\. /g, '.').slice(0, -1)} (KST)
+                          <br />
+                          <span>
+                            {new Date(patient.visits[patient.visits.length - 1].visit_date).toLocaleTimeString('ko-KR', {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              hour12: false
+                            })}
+                          </span>
+                        </>
+                      ) : '-'}
+                    </td>
+                    <td>{patient.visits?.[patient.visits.length - 1]?.los_hours || '-'}시간</td>
                     <td>{patient.visits?.[0]?.tas || '-'}</td>
                     <td>
                       <button 


### PR DESCRIPTION
patient에 피 검사 데이터를 순수 텍스트에서 정상/비정상 범위를 구분하여 비정상 데이터를 원형 그래프로 표시.
또한 수치보기를 누르면 표 형식으로 전체 수치를 볼 수 있도록 데이터 포맷팅.

상세정보 내 배치 추천 부분을 ktas레벨 기반이 아닌 모델을 가져와서 쓸 수 있도록 자리를 비워둠.

list.js에서 기존 5명에서 10명씩 환자가 출력되도록 변경.

방문 시간을 표시하고 체류 시간 표시할 때 인덱스 마지막으로 설정해서 가장 최근의 기록을 가져옴.

