### PR TITLE
feat: 설정 페이지 개선 (여백 추가 및 가독성 향상, 버튼 추가)

### DIFF
--- a/back/src/main/java/kr/spring/controller/AdminController.java
+++ b/back/src/main/java/kr/spring/controller/AdminController.java
@@ -6,7 +6,7 @@ import java.util.Map; // 불일치 분석 및 대시보드 데이터를 저장�
 import org.springframework.beans.factory.annotation.Autowired; // AdminService 의존성 주입을 위해 필요
 import org.springframework.http.HttpStatus; // HTTP 상태 코드 반환을 위해 필요
 import org.springframework.http.MediaType; // JSON 응답의 Content-Type 설정을 위해 필요
-import org.springframework.http.ResponseEntity; 기존: HTTP 응답 객체 생성에 사용
+import org.springframework.http.ResponseEntity; // HTTP 응답 객체 생성에 사용
 import org.springframework.web.bind.annotation.GetMapping; // GET 요청 매핑을 위해 필요
 import org.springframework.web.bind.annotation.RequestMapping; // 기본 URL 경로 설정에 사용
 import org.springframework.web.bind.annotation.RestController; // RESTful 컨트롤러로 설정하기 위해 필요

--- a/front/src/Components/admin/settings/Settings.js
+++ b/front/src/Components/admin/settings/Settings.js
@@ -15,9 +15,9 @@ const MAINTENANCE_CONTACT = {
 const SettingsCard = ({ title, icon: Icon, children }) => (
   <div className="bg-white rounded-lg shadow-sm overflow-hidden">
     <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-      <div className="flex items-center gap-2">
-        <Icon className="h-5 w-5 text-gray-500" />
-        <h3 className="text-lg font-medium text-gray-900">{title}</h3>
+      <div className="flex">
+        <Icon className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
+        <h3 className="ml-3 text-lg font-medium text-gray-900">{title}</h3>
       </div>
     </div>
     <div className="px-4 py-3">{children}</div>
@@ -86,64 +86,66 @@ const WeightSettings = ({ showNotification }) => {
 
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">퇴원</label>
-          <input
-            type="number"
-            value={weights.discharge}
-            onChange={(e) => handleWeightChange('discharge', e.target.value)}
-            step="0.1"
-            min="0.0"
-            max="0.9"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-          />
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">퇴원 가중치</label>
+            <input
+              type="number"
+              value={weights.discharge}
+              onChange={(e) => handleWeightChange('discharge', e.target.value)}
+              step="0.1"
+              min="0.0"
+              max="0.9"
+              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">일반병동 가중치</label>
+            <input
+              type="number"
+              value={weights.ward}
+              onChange={(e) => handleWeightChange('ward', e.target.value)}
+              step="0.1"
+              min="0.0"
+              max="0.9"
+              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">중환자실 가중치</label>
+            <input
+              type="number"
+              value={weights.icu}
+              onChange={(e) => handleWeightChange('icu', e.target.value)}
+              step="0.1"
+              min="0.0"
+              max="0.9"
+              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
+          </div>
         </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">일반병동</label>
-          <input
-            type="number"
-            value={weights.ward}
-            onChange={(e) => handleWeightChange('ward', e.target.value)}
-            step="0.1"
-            min="0.0"
-            max="0.9"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">중증병동</label>
-          <input
-            type="number"
-            value={weights.icu}
-            onChange={(e) => handleWeightChange('icu', e.target.value)}
-            step="0.1"
-            min="0.0"
-            max="0.9"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-          />
+
+        <div className="flex items-end">
+          <button
+            onClick={handleWeightsSave}
+            className="h-10 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 whitespace-nowrap"
+          >
+            <Save className="h-4 w-4 mr-2" />
+            가중치 설정 저장
+          </button>
         </div>
       </div>
 
-      <div className="mt-2 text-sm text-gray-500 bg-blue-50 p-3 rounded-md flex items-start gap-2">
+      <div className="text-sm text-gray-500 bg-blue-50 p-3 rounded-md flex items-start gap-2">
         <Info className="h-5 w-5 text-blue-400 mt-0.5 flex-shrink-0" />
         <p>
           각 영역별 가중치 값은 현재 DB에 저장된 값입니다.
-          <br /><br />
+          <br />
           <span className="font-medium">- 가중치 범위: 0.0 ~ 0.9</span>
           <br />
           <span className="font-medium">- 저장 버튼을 클릭해야 변경사항이 적용됩니다.</span>
         </p>
-      </div>
-
-      <div className="flex justify-end mt-3">
-        <button
-          onClick={handleWeightsSave}
-          className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-        >
-          <Save className="h-4 w-4 mr-2" />
-          가중치 설정 저장
-        </button>
       </div>
     </div>
   );
@@ -161,7 +163,6 @@ const BedSettings = ({ showNotification }) => {
 
   const handleBedCapacitySave = async () => {
     try {
-      // API 엔드포인트는 실제 환경에 맞게 수정하세요
       await axios.put('http://localhost:8082/boot/beds/capacity', bedCapacity);
       showNotification('병상 수 설정이 저장되었습니다.', 'success');
     } catch (error) {

--- a/front/src/Components/admin/settings/Settings.js
+++ b/front/src/Components/admin/settings/Settings.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Save, Info, Bell, Hospital, Building, Phone, Mail, MapPin } from 'lucide-react';
 import axios from 'axios';
+import { Save, Info, Bell, Hospital, Building, Phone, Mail, MapPin } from 'lucide-react';
 
-// 유지보수 담당자 정보 하드코딩
 const MAINTENANCE_CONTACT = {
   company: 'hosFit Solutions Co., Ltd.',
   department: '의료정보시스템팀',
@@ -15,62 +14,40 @@ const MAINTENANCE_CONTACT = {
 
 const SettingsCard = ({ title, icon: Icon, children }) => (
   <div className="bg-white rounded-lg shadow-sm overflow-hidden">
-    <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+    <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
       <div className="flex items-center gap-2">
         <Icon className="h-5 w-5 text-gray-500" />
         <h3 className="text-lg font-medium text-gray-900">{title}</h3>
       </div>
     </div>
-    <div className="p-6">{children}</div>
+    <div className="px-4 py-3">{children}</div>
   </div>
 );
 
-const Settings = ({ showNotification }) => {
+const WeightSettings = ({ showNotification }) => {
   const [weights, setWeights] = useState({
     discharge: 0.5,
     ward: 0.6,
     icu: 0.7
   });
-  
-  // 병상 설정 상태
-  const [bedCapacity, setBedCapacity] = useState({
-    totalBeds: 48,
-    criticalBeds: 10,
-    regularBeds: 38
-  });
 
-  // 초기 가중치 값을 서버에서 로드
   useEffect(() => {
     const fetchWeights = async () => {
       try {
         const response = await axios.get('http://localhost:8082/boot/thresholds/display');
         const thresholds = response.data;
-        
-        console.log('Received thresholds:', thresholds);
-        
-        // 데이터 매핑
-        const thresholdMap = {};
-        thresholds.forEach(item => {
-          if(item.key && typeof item.value === 'number') {
-            thresholdMap[item.key] = item.value;
-          }
-        });
-
-        console.log('Mapped thresholds:', thresholdMap);
-
         setWeights({
-          discharge: thresholdMap.DISCHARGE || 0.5,
-          ward: thresholdMap.WARD || 0.6,
-          icu: thresholdMap.ICU || 0.7
+          discharge: thresholds.find(t => t.key === 'DISCHARGE')?.value ?? 0.5,
+          ward: thresholds.find(t => t.key === 'WARD')?.value ?? 0.6,
+          icu: thresholds.find(t => t.key === 'ICU')?.value ?? 0.7
         });
       } catch (error) {
         console.error('가중치 로드 오류:', error);
         showNotification('가중치 로드 중 오류가 발생했습니다.', 'error');
       }
     };
-
     fetchWeights();
-  }, []);
+  }, [showNotification]);
 
   const handleWeightChange = (type, value) => {
     const numValue = Math.min(Math.max(parseFloat(value) || 0, 0.0), 0.9);
@@ -80,221 +57,192 @@ const Settings = ({ showNotification }) => {
     }));
   };
 
-  // 병상 수 변경 핸들러
-  const handleBedCapacityChange = (field, value) => {
-    const numValue = parseInt(value) || 0;
-    setBedCapacity(prev => {
-      const newState = { ...prev, [field]: numValue };
-      if (field === 'totalBeds') {
-        const ratio = prev.criticalBeds / (prev.criticalBeds + prev.regularBeds);
-        newState.criticalBeds = Math.round(numValue * ratio);
-        newState.regularBeds = numValue - newState.criticalBeds;
-      }
-      return newState;
-    });
-  };
-
-  const validateSettings = () => {
+  const validateWeights = () => {
     if (weights.discharge > weights.ward || weights.ward > weights.icu) {
       showNotification('가중치는 중환자실 > 일반병동 > 퇴원 순서로 설정되어야 합니다.', 'error');
       return false;
     }
-
     if (Object.values(weights).some(w => w > 0.9 || w < 0)) {
       showNotification('가중치는 0.0에서 0.9 사이의 값이어야 합니다.', 'error');
       return false;
     }
-
-    if (bedCapacity.totalBeds <= 0) {
-      showNotification('전체 병상 수는 0보다 커야 합니다.', 'error');
-      return false;
-    }
-
     return true;
   };
 
   const handleWeightsSave = async () => {
-    if (!validateSettings()) return;
-    
+    if (!validateWeights()) return;
     try {
-      console.log('Saving weights:', weights);
-      
       await Promise.all([
-        axios.put(`http://localhost:8082/boot/thresholds/DISCHARGE`, {
-          value: weights.discharge  // thresholdKey 제거, value만 전송
-        }),
-        axios.put(`http://localhost:8082/boot/thresholds/WARD`, {
-          value: weights.ward  // thresholdKey 제거, value만 전송
-        }),
-        axios.put(`http://localhost:8082/boot/thresholds/ICU`, {
-          value: weights.icu  // thresholdKey 제거, value만 전송
-        })
+        axios.put('http://localhost:8082/boot/thresholds/DISCHARGE', { value: weights.discharge }),
+        axios.put('http://localhost:8082/boot/thresholds/WARD', { value: weights.ward }),
+        axios.put('http://localhost:8082/boot/thresholds/ICU', { value: weights.icu })
       ]);
-        
       showNotification('가중치 설정이 저장되었습니다.', 'success');
-
-      // 저장 성공 후 가중치 다시 로드
-      const response = await axios.get('http://localhost:8082/boot/thresholds/display');
-      const thresholds = response.data;
-      
-      // 데이터 매핑
-      const thresholdMap = {};
-      thresholds.forEach(item => {
-        if(item.key && typeof item.value === 'number') {
-          thresholdMap[item.key] = item.value;
-        }
-      });
-
-      setWeights({
-        discharge: thresholdMap.DISCHARGE || weights.discharge,
-        ward: thresholdMap.WARD || weights.ward,
-        icu: thresholdMap.ICU || weights.icu
-      });
-
     } catch (error) {
       console.error('가중치 저장 오류:', error);
-      if (error.response) {
-        console.error('Error response:', error.response.data);
-        console.error('Error status:', error.response.status);
-      }
-      const errorMessage = error.response?.data?.message || '가중치 저장 중 오류가 발생했습니다.';
-      showNotification(errorMessage, 'error');
+      showNotification('가중치 저장 중 오류가 발생했습니다.', 'error');
     }
   };
 
   return (
-    <div className="p-6 space-y-6">
-      {/* 가중치 설정 섹션 */}
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">퇴원</label>
+          <input
+            type="number"
+            value={weights.discharge}
+            onChange={(e) => handleWeightChange('discharge', e.target.value)}
+            step="0.1"
+            min="0.0"
+            max="0.9"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">일반병동</label>
+          <input
+            type="number"
+            value={weights.ward}
+            onChange={(e) => handleWeightChange('ward', e.target.value)}
+            step="0.1"
+            min="0.0"
+            max="0.9"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">중증병동</label>
+          <input
+            type="number"
+            value={weights.icu}
+            onChange={(e) => handleWeightChange('icu', e.target.value)}
+            step="0.1"
+            min="0.0"
+            max="0.9"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="mt-2 text-sm text-gray-500 bg-blue-50 p-3 rounded-md flex items-start gap-2">
+        <Info className="h-5 w-5 text-blue-400 mt-0.5 flex-shrink-0" />
+        <p>
+          각 영역별 가중치 값은 현재 DB에 저장된 값입니다.
+          <br /><br />
+          <span className="font-medium">- 가중치 범위: 0.0 ~ 0.9</span>
+          <br />
+          <span className="font-medium">- 저장 버튼을 클릭해야 변경사항이 적용됩니다.</span>
+        </p>
+      </div>
+
+      <div className="flex justify-end mt-3">
+        <button
+          onClick={handleWeightsSave}
+          className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          <Save className="h-4 w-4 mr-2" />
+          가중치 설정 저장
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const BedSettings = ({ showNotification }) => {
+  const [bedCapacity, setBedCapacity] = useState({
+    totalBeds: 48
+  });
+
+  const handleBedCapacityChange = (value) => {
+    const numValue = parseInt(value) || 0;
+    setBedCapacity({ totalBeds: numValue });
+  };
+
+  const handleBedCapacitySave = async () => {
+    try {
+      // API 엔드포인트는 실제 환경에 맞게 수정하세요
+      await axios.put('http://localhost:8082/boot/beds/capacity', bedCapacity);
+      showNotification('병상 수 설정이 저장되었습니다.', 'success');
+    } catch (error) {
+      console.error('병상 수 저장 오류:', error);
+      showNotification('병상 수 저장 중 오류가 발생했습니다.', 'error');
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">전체 병상 수</label>
+        <div className="flex gap-3">
+          <input
+            type="number"
+            value={bedCapacity.totalBeds}
+            onChange={(e) => handleBedCapacityChange(e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          />
+          <button
+            onClick={handleBedCapacitySave}
+            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            <Save className="h-4 w-4 mr-2" />
+            병상 수 저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Settings = ({ showNotification }) => {
+  return (
+    <div className="p-4 space-y-4">
       <SettingsCard title="가중치 설정" icon={Save}>
-        <div className="space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* 퇴원 가중치 */}
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">퇴원 가중치</label>
-              <input
-                type="number"
-                value={weights.discharge}
-                onChange={(e) => handleWeightChange('discharge', e.target.value)}
-                step="0.1"
-                min="0.0"
-                max="0.9"
-                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              />
-            </div>
-
-            {/* 일반병동 가중치 */}
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">일반병동 가중치</label>
-              <input
-                type="number"
-                value={weights.ward}
-                onChange={(e) => handleWeightChange('ward', e.target.value)}
-                step="0.1"
-                min="0.0"
-                max="0.9"
-                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              />
-            </div>
-
-            {/* 중환자실 가중치 */}
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">중환자실 가중치</label>
-              <input
-                type="number"
-                value={weights.icu}
-                onChange={(e) => handleWeightChange('icu', e.target.value)}
-                step="0.1"
-                min="0.0"
-                max="0.9"
-                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              />
-            </div>
-          </div>
-
-          {/* 가중치 설정 안내 */}
-          <div className="mt-4 text-sm text-gray-500 bg-blue-50 p-4 rounded-md flex items-start gap-2">
-            <Info className="h-5 w-5 text-blue-400 mt-0.5 flex-shrink-0" />
-            <p>
-              각 영역별 가중치 값은 현재 DB에 저장된 값입니다.
-              <br /><br />
-              <span className="font-medium">- 가중치 범위: 0.0 ~ 0.9</span>
-              <br />
-              <span className="font-medium">- 저장 버튼을 클릭해야 변경사항이 적용됩니다.</span>
-            </p>
-          </div>
-
-          <div className="flex justify-end mt-6">
-            <button
-              onClick={handleWeightsSave}
-              className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-            >
-              <Save className="h-4 w-4 mr-2" />
-              가중치 설정 저장
-            </button>
-          </div>
-        </div>
+        <WeightSettings showNotification={showNotification} />
       </SettingsCard>
 
-      {/* 병상 설정 */}
       <SettingsCard title="병상 설정" icon={Hospital}>
-        <div className="space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">전체 병상 수</label>
-              <input
-                type="number"
-                value={bedCapacity.totalBeds}
-                onChange={(e) => handleBedCapacityChange('totalBeds', e.target.value)}
-                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              />
-            </div>
-          </div>
-        </div>
+        <BedSettings showNotification={showNotification} />
       </SettingsCard>
 
-      {/* 유지보수 담당자 정보 */}
       <SettingsCard title="유지보수 담당자 정보" icon={Bell}>
-        <div className="bg-gray-50 rounded-lg p-6">
+        <div className="bg-gray-50 rounded-lg p-4">
           <div className="space-y-4">
-            {/* 회사 정보 */}
-            <div className="flex items-center gap-2">
-              <Building className="h-5 w-5 text-gray-400" />
-              <div>
+            <div className="flex">
+              <Building className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
+              <div className="ml-3">
                 <p className="font-medium text-gray-900">{MAINTENANCE_CONTACT.company}</p>
                 <p className="text-sm text-gray-500">{MAINTENANCE_CONTACT.department}</p>
               </div>
             </div>
 
-            {/* 담당자 정보 */}
-            <div className="flex items-center gap-2">
-              <div className="h-5 w-5 flex justify-center text-gray-400">👤</div>
-              <div>
+            <div className="flex">
+              <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-gray-400 mt-1">👤</span>
+              <div className="ml-3">
                 <p className="font-medium text-gray-900">{MAINTENANCE_CONTACT.name}</p>
                 <p className="text-sm text-gray-500">{MAINTENANCE_CONTACT.position}</p>
               </div>
             </div>
 
-            {/* 연락처 정보 */}
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Phone className="h-5 w-5 text-gray-400" />
-                <p className="text-gray-600">{MAINTENANCE_CONTACT.phone}</p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Mail className="h-5 w-5 text-gray-400" />
-                <p className="text-gray-600">{MAINTENANCE_CONTACT.email}</p>
-              </div>
-              <div className="flex items-center gap-2">
-                <MapPin className="h-5 w-5 text-gray-400" />
-                <p className="text-gray-600">{MAINTENANCE_CONTACT.address}</p>
-              </div>
+            <div className="flex items-start">
+              <Phone className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
+              <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.phone}</p>
+            </div>
+
+            <div className="flex items-start">
+              <Mail className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
+              <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.email}</p>
+            </div>
+
+            <div className="flex items-start">
+              <MapPin className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
+              <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.address}</p>
             </div>
           </div>
 
-          {/* 알림 메시지 */}
-          <div className="mt-6 text-sm text-gray-500 bg-yellow-50 p-4 rounded-md flex items-start gap-2">
-            <Info className="h-5 w-5 text-yellow-400 mt-0.5 flex-shrink-0" />
-            <p>
+          <div className="mt-4 text-sm text-gray-500 bg-yellow-50 p-3 rounded-md flex items-start">
+            <Info className="h-5 w-5 text-yellow-400 mt-1 flex-shrink-0" />
+            <p className="ml-2">
               유지보수 담당자 정보는 시스템 관리자만 수정할 수 있습니다.
               <br />
               정보 수정이 필요한 경우 시스템 관리자에게 문의해 주세요.

--- a/front/src/Components/admin/settings/Settings.js
+++ b/front/src/Components/admin/settings/Settings.js
@@ -1,19 +1,28 @@
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-import { Save, Info, Bell, Hospital, Building, Phone, Mail, MapPin } from 'lucide-react';
-
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import {
+  Save,
+  Info,
+  Bell,
+  Hospital,
+  Building,
+  Phone,
+  Mail,
+  MapPin,
+} from "lucide-react";
+// 유지보수 담당자 정보 상수
 const MAINTENANCE_CONTACT = {
-  company: 'hosFit Solutions Co., Ltd.',
-  department: '의료정보시스템팀',
-  name: '김유지',
-  position: '수석 엔지니어',
-  email: 'maintenance@hosfit.co.kr',
-  phone: '02-1234-5678',
-  address: '서울특별시 강남구 테헤란로 123 호스핏빌딩 15층'
+  company: "hosFit Solutions Co., Ltd.",
+  department: "의료정보시스템팀",
+  name: "김유지",
+  position: "수석 엔지니어",
+  email: "maintenance@hosfit.co.kr",
+  phone: "02-1234-5678",
+  address: "서울특별시 강남구 테헤란로 123 호스핏빌딩 15층",
 };
-
+// 카드 형식 UI 컴포넌트 (공통 컴포넌트)
 const SettingsCard = ({ title, icon: Icon, children }) => (
-  <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+  <div className="bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow overflow-hidden border border-gray-100">
     <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
       <div className="flex">
         <Icon className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
@@ -23,47 +32,53 @@ const SettingsCard = ({ title, icon: Icon, children }) => (
     <div className="px-4 py-3">{children}</div>
   </div>
 );
-
+// 가중치 설정 관련 컴포넌트
 const WeightSettings = ({ showNotification }) => {
   const [weights, setWeights] = useState({
     discharge: 0.5,
     ward: 0.6,
-    icu: 0.7
+    icu: 0.7,
   });
-
+  // 가중치 상태 관리 및 초기 값 로드
   useEffect(() => {
     const fetchWeights = async () => {
       try {
-        const response = await axios.get('http://localhost:8082/boot/thresholds/display');
+        const response = await axios.get(
+          "http://localhost:8082/boot/thresholds/display"
+        );
         const thresholds = response.data;
         setWeights({
-          discharge: thresholds.find(t => t.key === 'DISCHARGE')?.value ?? 0.5,
-          ward: thresholds.find(t => t.key === 'WARD')?.value ?? 0.6,
-          icu: thresholds.find(t => t.key === 'ICU')?.value ?? 0.7
+          discharge:
+            thresholds.find((t) => t.key === "DISCHARGE")?.value ?? 0.5,
+          ward: thresholds.find((t) => t.key === "WARD")?.value ?? 0.6,
+          icu: thresholds.find((t) => t.key === "ICU")?.value ?? 0.7,
         });
       } catch (error) {
-        console.error('가중치 로드 오류:', error);
-        showNotification('가중치 로드 중 오류가 발생했습니다.', 'error');
+        console.error("가중치 로드 오류:", error);
+        showNotification("가중치 로드 중 오류가 발생했습니다.", "error");
       }
     };
     fetchWeights();
   }, [showNotification]);
-
+  // 가중치 유효성 검사 및 저장 로직
   const handleWeightChange = (type, value) => {
     const numValue = Math.min(Math.max(parseFloat(value) || 0, 0.0), 0.9);
-    setWeights(prev => ({
+    setWeights((prev) => ({
       ...prev,
-      [type]: numValue
+      [type]: numValue,
     }));
   };
 
   const validateWeights = () => {
     if (weights.discharge > weights.ward || weights.ward > weights.icu) {
-      showNotification('가중치는 중환자실 > 일반병동 > 퇴원 순서로 설정되어야 합니다.', 'error');
+      showNotification(
+        "가중치는 중증병동 > 일반병동 > 퇴원 순서로 설정되어야 합니다.",
+        "error"
+      );
       return false;
     }
-    if (Object.values(weights).some(w => w > 0.9 || w < 0)) {
-      showNotification('가중치는 0.0에서 0.9 사이의 값이어야 합니다.', 'error');
+    if (Object.values(weights).some((w) => w > 0.9 || w < 0)) {
+      showNotification("가중치는 0.0에서 0.9 사이의 값이어야 합니다.", "error");
       return false;
     }
     return true;
@@ -73,87 +88,93 @@ const WeightSettings = ({ showNotification }) => {
     if (!validateWeights()) return;
     try {
       await Promise.all([
-        axios.put('http://localhost:8082/boot/thresholds/DISCHARGE', { value: weights.discharge }),
-        axios.put('http://localhost:8082/boot/thresholds/WARD', { value: weights.ward }),
-        axios.put('http://localhost:8082/boot/thresholds/ICU', { value: weights.icu })
+        axios.put("http://localhost:8082/boot/thresholds/DISCHARGE", {
+          value: weights.discharge,
+        }),
+        axios.put("http://localhost:8082/boot/thresholds/WARD", {
+          value: weights.ward,
+        }),
+        axios.put("http://localhost:8082/boot/thresholds/ICU", {
+          value: weights.icu,
+        }),
       ]);
-      showNotification('가중치 설정이 저장되었습니다.', 'success');
+      showNotification("가중치 설정이 저장되었습니다.", "success");
     } catch (error) {
-      console.error('가중치 저장 오류:', error);
-      showNotification('가중치 저장 중 오류가 발생했습니다.', 'error');
+      console.error("가중치 저장 오류:", error);
+      showNotification("가중치 저장 중 오류가 발생했습니다.", "error");
     }
   };
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-col lg:flex-row gap-4">
-        <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">퇴원 가중치</label>
-            <input
-              type="number"
-              value={weights.discharge}
-              onChange={(e) => handleWeightChange('discharge', e.target.value)}
-              step="0.1"
-              min="0.0"
-              max="0.9"
-              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            />
+      <div className="mx-6">
+        <div className="flex flex-col lg:flex-row gap-4">
+          <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1 transition-colors hover:text-blue-600">
+                퇴원 가중치
+              </label>
+              <input
+                type="number"
+                value={weights.discharge}
+                onChange={(e) =>
+                  handleWeightChange("discharge", e.target.value)
+                }
+                step="0.1"
+                min="0.0"
+                max="0.9"
+                className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-blue-300 transition-colors sm:text-sm bg-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1 transition-colors hover:text-blue-600">
+                일반병동 가중치
+              </label>
+              <input
+                type="number"
+                value={weights.ward}
+                onChange={(e) => handleWeightChange("ward", e.target.value)}
+                step="0.1"
+                min="0.0"
+                max="0.9"
+                className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-blue-300 transition-colors sm:text-sm bg-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1 transition-colors hover:text-blue-600">
+                중증병동 가중치
+              </label>
+              <input
+                type="number"
+                value={weights.icu}
+                onChange={(e) => handleWeightChange("icu", e.target.value)}
+                step="0.1"
+                min="0.0"
+                max="0.9"
+                className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-blue-300 transition-colors sm:text-sm bg-white"
+              />
+            </div>
           </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">일반병동 가중치</label>
-            <input
-              type="number"
-              value={weights.ward}
-              onChange={(e) => handleWeightChange('ward', e.target.value)}
-              step="0.1"
-              min="0.0"
-              max="0.9"
-              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">중환자실 가중치</label>
-            <input
-              type="number"
-              value={weights.icu}
-              onChange={(e) => handleWeightChange('icu', e.target.value)}
-              step="0.1"
-              min="0.0"
-              max="0.9"
-              className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-            />
+
+          <div className="flex items-end lg:justify-end">
+            <button
+              onClick={handleWeightsSave}
+              className="h-10 w-[180px] inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 hover:scale-105 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <Save className="h-4 w-4 mr-2" />
+              가중치 설정 저장
+            </button>
           </div>
         </div>
-
-        <div className="flex items-end">
-          <button
-            onClick={handleWeightsSave}
-            className="h-10 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 whitespace-nowrap"
-          >
-            <Save className="h-4 w-4 mr-2" />
-            가중치 설정 저장
-          </button>
-        </div>
-      </div>
-
-      <div className="text-sm text-gray-500 bg-blue-50 p-3 rounded-md flex items-start gap-2">
-        <Info className="h-5 w-5 text-blue-400 mt-0.5 flex-shrink-0" />
-        <p>
-          각 영역별 가중치 값은 현재 DB에 저장된 값입니다.
-          <br />
-          <span className="font-medium">- 가중치 범위: 0.0 ~ 0.9</span>
-          <br />
-          <span className="font-medium">- 저장 버튼을 클릭해야 변경사항이 적용됩니다.</span>
-        </p>
       </div>
     </div>
   );
 };
-
+// 병상 설정 관련 컴포넌트
 const BedSettings = ({ showNotification }) => {
+   // 병상 수 상태 관리 및 저장 로직
   const [bedCapacity, setBedCapacity] = useState({
-    totalBeds: 48
+    totalBeds: 48,
   });
 
   const handleBedCapacityChange = (value) => {
@@ -163,38 +184,42 @@ const BedSettings = ({ showNotification }) => {
 
   const handleBedCapacitySave = async () => {
     try {
-      await axios.put('http://localhost:8082/boot/beds/capacity', bedCapacity);
-      showNotification('병상 수 설정이 저장되었습니다.', 'success');
+      await axios.put("http://localhost:8082/boot/beds/capacity", bedCapacity);
+      showNotification("병상 수 설정이 저장되었습니다.", "success");
     } catch (error) {
-      console.error('병상 수 저장 오류:', error);
-      showNotification('병상 수 저장 중 오류가 발생했습니다.', 'error');
+      console.error("병상 수 저장 오류:", error);
+      showNotification("병상 수 저장 중 오류가 발생했습니다.", "error");
     }
   };
 
   return (
     <div className="space-y-3">
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">전체 병상 수</label>
-        <div className="flex gap-3">
-          <input
-            type="number"
-            value={bedCapacity.totalBeds}
-            onChange={(e) => handleBedCapacityChange(e.target.value)}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-          />
-          <button
-            onClick={handleBedCapacitySave}
-            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            <Save className="h-4 w-4 mr-2" />
-            병상 수 저장
-          </button>
+      <div className="mx-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            전체 병상 수
+          </label>
+          <div className="flex gap-3">
+            <input
+              type="number"
+              value={bedCapacity.totalBeds}
+              onChange={(e) => handleBedCapacityChange(e.target.value)}
+              className="flex-1 h-10 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
+            <button
+              onClick={handleBedCapacitySave}
+              className="h-10 w-[180px] inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <Save className="h-4 w-4 mr-2" />
+              병상 수 저장
+            </button>
+          </div>
         </div>
       </div>
     </div>
   );
 };
-
+// Settings 전체 구성 컴포넌트
 const Settings = ({ showNotification }) => {
   return (
     <div className="p-4 space-y-4">
@@ -207,40 +232,47 @@ const Settings = ({ showNotification }) => {
       </SettingsCard>
 
       <SettingsCard title="유지보수 담당자 정보" icon={Bell}>
-        <div className="bg-gray-50 rounded-lg p-4">
-          <div className="space-y-4">
+        <div className="mx-6">
+          <div className="space-y-4 bg-gray-50 p-4 rounded-lg">
             <div className="flex">
               <Building className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
               <div className="ml-3">
-                <p className="font-medium text-gray-900">{MAINTENANCE_CONTACT.company}</p>
-                <p className="text-sm text-gray-500">{MAINTENANCE_CONTACT.department}</p>
+                <p className="font-medium text-gray-900">
+                  {MAINTENANCE_CONTACT.company}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {MAINTENANCE_CONTACT.department}
+                </p>
               </div>
             </div>
-
             <div className="flex">
-              <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-gray-400 mt-1">👤</span>
+              <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-gray-400 mt-1">
+                👤
+              </span>
               <div className="ml-3">
-                <p className="font-medium text-gray-900">{MAINTENANCE_CONTACT.name}</p>
-                <p className="text-sm text-gray-500">{MAINTENANCE_CONTACT.position}</p>
+                <p className="font-medium text-gray-900">
+                  {MAINTENANCE_CONTACT.name}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {MAINTENANCE_CONTACT.position}
+                </p>
               </div>
             </div>
-
             <div className="flex items-start">
               <Phone className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
               <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.phone}</p>
             </div>
-
             <div className="flex items-start">
               <Mail className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
               <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.email}</p>
             </div>
-
             <div className="flex items-start">
               <MapPin className="h-5 w-5 text-gray-400 mt-1 flex-shrink-0" />
-              <p className="ml-3 text-gray-600">{MAINTENANCE_CONTACT.address}</p>
+              <p className="ml-3 text-gray-600">
+                {MAINTENANCE_CONTACT.address}
+              </p>
             </div>
           </div>
-
           <div className="mt-4 text-sm text-gray-500 bg-yellow-50 p-3 rounded-md flex items-start">
             <Info className="h-5 w-5 text-yellow-400 mt-1 flex-shrink-0" />
             <p className="ml-2">

--- a/front/src/Components/layout/Sidebar.js
+++ b/front/src/Components/layout/Sidebar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Users, AlertCircle, Sliders } from 'lucide-react'; // 필요한 아이콘을 lucide-react 라이브러리에서 불러옵니다.
+import { Grid, Users, AlertCircle, Sliders, Settings } from 'lucide-react'; // 필요한 아이콘을 lucide-react 라이브러리에서 불러옵니다.
 import "../layout/Sidbar.css"; // 사이드바에 대한 추가 스타일을 적용하기 위해 CSS 파일을 import
 
 /**
@@ -92,7 +92,7 @@ const Sidebar = ({ activeTab, onTabChange, logout, userName }) => (
         />
         <NavLink
           active={activeTab === 'settings'}
-          icon={Sliders} // 설정 아이콘
+          icon={Settings} // 설정 아이콘
           label="설정"
           onClick={() => onTabChange('settings')}
         />


### PR DESCRIPTION
📌 주요 변경 사항
🛠️ 설정 페이지 개선
- 새 버튼 추가
  - 가중치 및 병상 설정 저장을 위한 버튼 추가.
  - 버튼 기능을 명확히 하여 사용자 경험 개선.

- 버튼 크기 통일
  - 기존 설정 화면의 저장 버튼 크기를 조정하여 모든 버튼이 동일한 크기를 가지도록 개선.

🎨 UI 디자인 정리
- 섹션 간 여백 조정
  - 섹션 간 간격을 늘려 화면이 더 명확히 구분되도록 수정.

- SettingsCard 활용
  - 각 섹션의 제목과 아이콘 정렬 문제 해결.
  
✨ 추가 개선
- 레이아웃 통일성 강화
- 좌우 여백을 균일하게 조정하여 디자인 일관성을 유지.

🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/b3d613c3-7b59-463f-bd3e-462201565bad)
![image](https://github.com/user-attachments/assets/858cd635-e0ce-41a0-abb3-5fd29e096536)
**구 설정 페이지**

![image](https://github.com/user-attachments/assets/4e6bf2e7-366e-4dd7-bbbc-834cf0c335cb)
**현 설정 페이지**
